### PR TITLE
Collect BandCamp links

### DIFF
--- a/assets/templates/history.html
+++ b/assets/templates/history.html
@@ -13,7 +13,7 @@
 {{- range .}}
     <div class="suggestion">
         <p>{{.Message}}</p>
-        <span>Suggested by <em>{{.User}}</em> on {{.Date}} // <a href="https://youtube.com/watch?v={{.VideoID}}" target="_blank"><em>Play</em></a></span>
+        <span>Suggested by <em>{{.User}}</em> on {{.Date}} // <a href="{{.VideoID}}" target="_blank"><em>Play</em></a></span>
     </div>
 {{- end}}
 </body>

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -13,7 +13,7 @@
 		{{- range .}}
 		<div class="suggestion">
 			<p>{{.Message}}</p>
-			<span>Suggested by <em>{{.User}}</em> // <a href="https://youtube.com/watch?v={{.VideoID}}" target="_blank"><em>Play</em></a> // <a href="/play?id={{.ID}}"><em>Remove</em> and add to played</a> // <a href="/delete?id={{.ID}}"><em>Remove</em></a></span>
+			<span>Suggested by <em>{{.User}}</em> // <a href="{{.VideoID}}" target="_blank"><em>Play</em></a> // <a href="/play?id={{.ID}}"><em>Remove</em> and add to played</a> // <a href="/delete?id={{.ID}}"><em>Remove</em></a></span>
 		</div>
 		{{- end}}
 	</body>

--- a/irc.go
+++ b/irc.go
@@ -23,7 +23,7 @@ var (
 var (
 	ping    = regexp.MustCompile(`^PING :([^\r\n]+)\r\n$`)
 	privmsg = regexp.MustCompile(`^:([^\r\n @]+)![^\r\n @]+@[^\r\n @]+\.tmi\.twitch\.tv PRIVMSG [^\r\n ]+ :([^\r\n]+)\r\n$`)
-	youtube = regexp.MustCompile(`(?:youtube\.com/watch\?v=|youtu\.be/)([A-Za-z0-9_-]{11})`)
+	link    = regexp.MustCompile(`http[s?]:\/\/[(youtube.com\/watch\?v=|youtu.be\/|bandcamp.com\/)\S]+`)
 )
 
 var playlist = make(map[string]string)
@@ -149,13 +149,13 @@ func bot(user, msg string, send func(string) error) (err error) {
 			break
 		}
 	default:
-		if match := youtube.FindStringSubmatch(msg); match != nil {
+		if match := link.FindStringmsg); match != "" {
 			if user == "bravenewfavesbot" {
-				log.Printf("ignored link: %s", match[1])
+				log.Printf("ignored link: %s", match)
 			} else {
-				log.Printf("found link: %s", match[1])
+				log.Printf("found link: %s", match)
 				_, err := db.Exec("INSERT INTO submissions(user, videoid, message) VALUES(?, ?, ?);",
-					user, match[1], msg)
+					user, match, msg)
 				if err != nil {
 					log.Printf("adding submission: %v", err)
 				}


### PR DESCRIPTION
Now stores URLs of suggestions as the whole URL. BandCamp doesn't have
YouTube IDs. This has the added benefit of allowing users to link to a
specific time in a YouTube video.

Updates the youtube regexp to a more general regexp and adds the
regexp for BandCamp links.

Changes the Play link in templates to just the value of
videoid, which is now the whole URL.