### PR TITLE
Replace Snackpak with ZaxusEMK

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -17,7 +17,7 @@ const (
 
 var (
 	admins   = [...]string{"kathleen_lrr", "felixphew", "freshpriceofbeleren", "pterodactal"}
-	plAdmins = [...]string{"snackpak_", "setralynn"}
+	plAdmins = [...]string{"ZaxusEMK", "setralynn"}
 )
 
 var (


### PR DESCRIPTION
Snackpak has not been able to make Google Music playlists and ZaxusEMK has volunteered to, so this removes Snackpak and adds ZaxusEMK.